### PR TITLE
fix: incompatible func names of typer

### DIFF
--- a/typer.go
+++ b/typer.go
@@ -8,8 +8,8 @@ import (
 
 type TypeRegister interface {
 	AddTable(i interface{}) *gorp.TableMap
-	AddTableWith(i interface{}, name string) *gorp.TableMap
-	AddTableWithNameSchema(i interface{}, schema string, name string) *gorp.TableMap
+	AddTableWithName(i interface{}, name string) *gorp.TableMap
+	AddTableWithNameAndSchema(i interface{}, schema string, name string) *gorp.TableMap
 }
 
 type Typer struct {
@@ -39,10 +39,10 @@ func (t *Typer) AddTable(i interface{}) *gorp.TableMap {
 	return t.sniff(i, t.typeRegister.AddTable(i))
 }
 
-func (t *Typer) AddTableWith(i interface{}, name string) *gorp.TableMap {
-	return t.sniff(i, t.typeRegister.AddTableWith(i, name))
+func (t *Typer) AddTableWithName(i interface{}, name string) *gorp.TableMap {
+	return t.sniff(i, t.typeRegister.AddTableWithName(i, name))
 }
 
-func (t *Typer) AddTableWithNameSchema(i interface{}, schema string, name string) *gorp.TableMap {
-	return t.sniff(i, t.typeRegister.AddTableWithNameSchema(i, schema, name))
+func (t *Typer) AddTableWithNameAndSchema(i interface{}, schema string, name string) *gorp.TableMap {
+	return t.sniff(i, t.typeRegister.AddTableWithNameAndSchema(i, schema, name))
 }


### PR DESCRIPTION
`gorp.DbMap` has these methods:
- [AddTableWithName](https://github.com/go-gorp/gorp/blob/master/db.go#L174)
- [AddTableWithNameAndSchema](https://github.com/go-gorp/gorp/blob/master/db.go#L180)

But your `typer.go` has `AddTableWith` and `AddTableWithNameSchema` . 
I've fixed it.