### PR TITLE
fix: test passing with gorp v2.1

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -1,8 +1,13 @@
 package gorputil
 
-import "database/sql"
+import (
+	"database/sql"
+	"gopkg.in/gorp.v2"
+	"context"
+)
 
 type MockSqlExecutor struct {
+	WithContextMock     func(ctx context.Context) gorp.SqlExecutor
 	GetMock             func(i interface{}, keys ...interface{}) (interface{}, error)
 	InsertMock          func(list ...interface{}) error
 	UpdateMock          func(list ...interface{}) (int64, error)
@@ -18,6 +23,10 @@ type MockSqlExecutor struct {
 	SelectOneMock       func(holder interface{}, query string, args ...interface{}) error
 	QueryMock           func(query string, args ...interface{}) (*sql.Rows, error)
 	QueryRowMock        func(query string, args ...interface{}) *sql.Row
+}
+
+func (m *MockSqlExecutor) WithContext(ctx context.Context) gorp.SqlExecutor {
+	return m.WithContextMock(ctx)
 }
 
 func (m *MockSqlExecutor) Get(i interface{}, keys ...interface{}) (interface{}, error) {


### PR DESCRIPTION
In gorp v2.1, `SqlExecutor` must be have `WithContext` method (maybe added in [this commit](https://github.com/go-gorp/gorp/commit/fe96e856d4ed65f604a6c1564df37c005bbd048f#diff-2841fa2e68bc8d48e439cb8034d4d5c5) )
Because of this commit, `mock.go` can't be compiled with gorp v2.1.

This PR fixed this issue.
